### PR TITLE
Update FlightFinder to Blazor 0.2.0-rc1-10203

### DIFF
--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/Search.cshtml
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/Search.cshtml
@@ -5,7 +5,7 @@
         <div class="col pr-0">
             <div class="form-control d-flex">
                 <div><i>✈</i>&nbsp;&nbsp;From:</div>
-                <input list="airports" placeholder="..." @bind(criteria.FromAirport) />
+                <input list="airports" placeholder="..." bind=criteria.FromAirport />
             </div>
         </div>
         <div class="col px-2 py-1 align-self-end arrow">➝</div>
@@ -14,7 +14,7 @@
         <div class="col pl-0">
             <div class="form-control d-flex">
                 <div><i>✈</i>&nbsp;&nbsp;To:</div>
-                <input list="airports" placeholder="..." @bind(criteria.ToAirport) />
+                <input list="airports" placeholder="..." bind=criteria.ToAirport />
             </div>
         </div>
     </div>
@@ -25,7 +25,7 @@
         <div class="col pr-0">
             <div class="form-control d-flex">
                 <div><i>🗓</i>&nbsp;&nbsp;Depart:</div>
-                <input type="date" @bind(criteria.OutboundDate, "yyyy-MM-dd") />
+                <input type="date" bind=criteria.OutboundDate format-value="yyyy-MM-dd" />
             </div>
         </div>
         <div class="col px-2 py-1 align-self-end arrow">➝</div>
@@ -34,7 +34,7 @@
         <div class="col pl-0">
             <div class="form-control d-flex">
                 <div><i>🗓</i>&nbsp;&nbsp;Arrive:</div>
-                <input type="date" @bind(criteria.ReturnDate, "yyyy-MM-dd") />
+                <input type="date" bind=criteria.ReturnDate format-value="yyyy-MM-dd" />
             </div>
         </div>
     </div>
@@ -42,7 +42,7 @@
     <!-- Class / search -->
     <div class="row py-1 d-flex px-3">
         <div>
-            <select class="custom-select" @bind(criteria.TicketClass)>
+            <select class="custom-select" bind=criteria.TicketClass>
                 <option value=@TicketClass.Economy>Economy</option>
                 <option value=@TicketClass.PremiumEconomy>Premium Economy</option>
                 <option value=@TicketClass.Business>Business</option>
@@ -50,7 +50,7 @@
             </select>
         </div>
         <div class="ml-auto">
-            <button @onclick(() => OnSearch(criteria)) type="button" class="btn btn-danger px-5">
+            <button onclick=@(() => OnSearch(criteria)) type="button" class="btn btn-danger px-5">
                 Search ➝
             </button>
         </div>

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/SearchResults.cshtml
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/SearchResults.cshtml
@@ -3,7 +3,7 @@
     {
         <div class="title">
             <h2 class="my-3">@Itineraries.Count results</h2>
-            <select class="custom-select" @bind(chosenSortOrder)>
+            <select class="custom-select" bind=chosenSortOrder>
                 <option value=@SortOrder.Price>Cheapest</option>
                 <option value=@SortOrder.Duration>Quickest</option>
             </select>
@@ -22,7 +22,7 @@
                 </ul>
                 <div class="price ml-3">
                     <h3>@item.Price.ToString("$0")</h3>
-                    <button class="btn" @onclick(() => OnAddItinerary(item))>Add</button>
+                    <button class="btn" onclick=@(() => OnAddItinerary(item))>Add</button>
                 </div>
             </div>
         }

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/Shortlist.cshtml
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/Shortlist.cshtml
@@ -8,7 +8,7 @@
                 <nobr>@item.Outbound.FromAirportCode</nobr> -
                 <nobr>@item.Outbound.ToAirportCode</nobr>
             </div>
-            <button type="button" class="close" aria-label="Close" @onclick(() => OnRemoveItinerary(item))>
+            <button type="button" class="close" aria-label="Close" onclick=@(() => OnRemoveItinerary(item))>
                 <span aria-hidden="true">&times;</span>
             </button>
         </li>

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/FlightFinder.Client.csproj
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/FlightFinder.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web;Microsoft.NET.Sdk.Razor/2.1.0-preview2-30230">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.0-preview2-30230" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.1.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.0-preview2-final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.2.0-rc1-10203" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.2.0-rc1-10203" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Server/FlightFinder.Server.csproj
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Server/FlightFinder.Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.2.0-rc1-10203" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/aspnetcore/blazor/FlightFinder/NuGet.config
+++ b/samples/aspnetcore/blazor/FlightFinder/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="blazor-dev" value="https://dotnet.myget.org/F/blazor-dev/api/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
We should publish this once the 0.2.0 tooling is released. Because if people try to open it with 0.1.0 tooling, it won't recognize the newer syntax.