### PR TITLE
Replace references to 'arrive' or 'arrival' to 'return' to be consistent

### DIFF
--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/Search.cshtml
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/Search.cshtml
@@ -19,7 +19,7 @@
         </div>
     </div>
 
-    <!-- Departure / arrival dates -->
+    <!-- Departure / return dates -->
     <div class="row py-1">
         <!-- Depart date -->
         <div class="col pr-0">
@@ -30,10 +30,10 @@
         </div>
         <div class="col px-2 py-1 align-self-end arrow">➝</div>
 
-        <!-- Arrive date -->
+        <!-- Return date -->
         <div class="col pl-0">
             <div class="form-control d-flex">
-                <div><i>🗓</i>&nbsp;&nbsp;Arrive:</div>
+                <div><i>🗓</i>&nbsp;&nbsp;Return:</div>
                 <input type="date" bind=criteria.ReturnDate format-value="yyyy-MM-dd" />
             </div>
         </div>

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/SearchResultFlightSegment.cshtml
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/SearchResultFlightSegment.cshtml
@@ -14,9 +14,9 @@
 
 <div class="arrow">➝</div>
 
-<div class="arrival">
-    <h4>@Flight.ArrivalTime.ToShortTimeString()</h4>
-    @Flight.ArrivalTime.ToString("ddd MMM d") (@Flight.ToAirportCode)
+<div class="return">
+    <h4>@Flight.ReturnTime.ToShortTimeString()</h4>
+    @Flight.ReturnTime.ToString("ddd MMM d") (@Flight.ToAirportCode)
 </div>
 
 <div class="duration">

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/ShortlistFlightSegment.cshtml
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/Components/ShortlistFlightSegment.cshtml
@@ -10,8 +10,8 @@
 
 <div class="arrow">➝</div>
 
-<div class="arrival">
-    <h4>@Flight.ArrivalTime.ToShortTimeString()</h4>
+<div class="return">
+    <h4>@Flight.ReturnTime.ToShortTimeString()</h4>
     @Flight.ToAirportCode
 </div>
 

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/wwwroot/css/site.css
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/wwwroot/css/site.css
@@ -191,7 +191,7 @@ body {
         text-align: center;
     }
 
-    #results-area .arrival {
+    #results-area .return {
         text-align: center;
         color: #777;
         font-size: 0.8rem !important;
@@ -251,7 +251,7 @@ body {
         flex: auto;
     }
 
-    #selections-area .departure, #selections-area .arrival, #selections-area .price {
+    #selections-area .departure, #selections-area .return, #selections-area .price {
         text-align: center;
         color: #777;
         font-size: 0.8rem !important;

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/wwwroot/css/site.scss
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Client/wwwroot/css/site.scss
@@ -194,7 +194,7 @@ body {
         text-align: center;
     }
 
-    .arrival {
+    .return {
         text-align: center;
         color: #777;
         font-size: 0.8rem !important;
@@ -254,7 +254,7 @@ body {
         flex: auto;
     }
 
-    .departure, .arrival, .price {
+    .departure, .return, .price {
         text-align: center;
         color: #777;
         font-size: 0.8rem !important;

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Server/Controllers/FlightSearchController.cs
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Server/Controllers/FlightSearchController.cs
@@ -24,7 +24,7 @@ namespace FlightFinder.Server.Controllers
                     FromAirportCode = criteria.FromAirport,
                     ToAirportCode = criteria.ToAirport,
                     DepartureTime = criteria.OutboundDate.AddHours(rng.Next(24)).AddMinutes(5 * rng.Next(12)),
-                    ArrivalTime = criteria.OutboundDate.AddHours(rng.Next(24)).AddMinutes(5 * rng.Next(12)),
+                    ReturnTime = criteria.OutboundDate.AddHours(rng.Next(24)).AddMinutes(5 * rng.Next(12)),
                     DurationHours = 2 + rng.Next(10),
                     TicketClass = criteria.TicketClass
                 },
@@ -34,7 +34,7 @@ namespace FlightFinder.Server.Controllers
                     FromAirportCode = criteria.ToAirport,
                     ToAirportCode = criteria.FromAirport,
                     DepartureTime = criteria.ReturnDate.AddHours(rng.Next(24)).AddMinutes(5 * rng.Next(12)),
-                    ArrivalTime = criteria.ReturnDate.AddHours(rng.Next(24)).AddMinutes(5 * rng.Next(12)),
+                    ReturnTime = criteria.ReturnDate.AddHours(rng.Next(24)).AddMinutes(5 * rng.Next(12)),
                     DurationHours = 2 + rng.Next(10),
                     TicketClass = criteria.TicketClass
                 },

--- a/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Shared/FlightSegment.cs
+++ b/samples/aspnetcore/blazor/FlightFinder/FlightFinder.Shared/FlightSegment.cs
@@ -8,7 +8,7 @@ namespace FlightFinder.Shared
         public string FromAirportCode { get; set; }
         public string ToAirportCode { get; set; }
         public DateTime DepartureTime { get; set; }
-        public DateTime ArrivalTime { get; set; }
+        public DateTime ReturnTime { get; set; }
         public double DurationHours { get; set; }
         public TicketClass TicketClass { get; set; }
     }


### PR DESCRIPTION
In @SteveSandersonMS demo an NDC in May the 'arrival' is perhaps the wrong phrase. Amended 'arrival' instances to 'return' in UI, code and CSS