### PR TITLE
Initialize the instance in the default constructor

### DIFF
--- a/samples/aspnet/Identity/AspNet.Identity.MySQL/RoleStore.cs
+++ b/samples/aspnet/Identity/AspNet.Identity.MySQL/RoleStore.cs
@@ -28,9 +28,8 @@ namespace AspNet.Identity.MySQL
         /// instance using the Default Connection string
         /// </summary>
         public RoleStore()
-        {
-            new RoleStore<TRole>(new MySQLDatabase());
-        }
+            : this(new MySQLDatabase())
+        { }
 
         /// <summary>
         /// Constructor that takes a MySQLDatabase as argument 


### PR DESCRIPTION
Actually initialize all class members from the default constructor
instead of creating a throw-away instance.