### PR TITLE
Fix zero length stream catch on Blazor InputLargeTextArea sample

### DIFF
--- a/samples/aspnetcore/blazor/InputLargeTextArea/src/InputLargeTextArea/InputLargeTextArea.cs
+++ b/samples/aspnetcore/blazor/InputLargeTextArea/src/InputLargeTextArea/InputLargeTextArea.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 // 0 length streams/textareas aren't permitted from JS->.NET Streaming Interop.
                 if (jsException.InnerException is ArgumentOutOfRangeException outOfRangeException &&
                     outOfRangeException.ActualValue is not null &&
-                    long.TryParse(outOfRangeException.ActualValue.ToString(), out var actualLength) &&
+                    outOfRangeException.ActualValue is long actualLength &&
                     actualLength == 0)
                 {
                     return StreamReader.Null;

--- a/samples/aspnetcore/blazor/InputLargeTextArea/src/InputLargeTextArea/InputLargeTextArea.cs
+++ b/samples/aspnetcore/blazor/InputLargeTextArea/src/InputLargeTextArea/InputLargeTextArea.cs
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Components.Forms
                 // 0 length streams/textareas aren't permitted from JS->.NET Streaming Interop.
                 if (jsException.InnerException is ArgumentOutOfRangeException outOfRangeException &&
                     outOfRangeException.ActualValue is not null &&
-                    outOfRangeException.ActualValue is int actualLength &&
+                    long.TryParse(outOfRangeException.ActualValue.ToString(), out var actualLength) &&
                     actualLength == 0)
                 {
                     return StreamReader.Null;


### PR DESCRIPTION
I ran into an issue with this sample where if the textarea was blank, it threw the argument out of range exception.
In my instance (running on .NET 6), the `outOfRangeException.ActualValue` property was of type long, but the exception catch assume it's an int.

To be safe, I do a long.TryParse. I'm not sure if it ever was an int. Long makes more sense for a stream. Either way, this would catch both and handle the error properly.

![image](https://user-images.githubusercontent.com/5124807/168122772-aab72471-6ee2-4ef6-a685-d54d061f8d78.png)

@TanayParikh
