### PR TITLE
Bump all other Owin packages to 4.2.2, not just Microsoft.Owin

### DIFF
--- a/samples/aspnet/Katana/WebSocketSample/WebSocketServer/WebSocketServer.csproj
+++ b/samples/aspnet/Katana/WebSocketSample/WebSocketServer/WebSocketServer.csproj
@@ -33,21 +33,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Owin, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Diagnostics, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Diagnostics, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.Diagnostics.3.0.0\lib\net45\Microsoft.Owin.Diagnostics.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Diagnostics.4.2.2\lib\net45\Microsoft.Owin.Diagnostics.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.0\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.4.2.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Hosting, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.0\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Hosting.4.2.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/samples/aspnet/Katana/WebSocketSample/WebSocketServer/packages.config
+++ b/samples/aspnet/Katana/WebSocketSample/WebSocketServer/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net45" />
-  <package id="Microsoft.Owin.Diagnostics" version="3.0.0" targetFramework="net45" />
-  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.0" targetFramework="net45" />
-  <package id="Microsoft.Owin.Hosting" version="3.0.0" targetFramework="net45" />
-  <package id="Microsoft.Owin.SelfHost" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Diagnostics" version="4.2.2" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="4.2.2" targetFramework="net45" />
+  <package id="Microsoft.Owin.Hosting" version="4.2.2" targetFramework="net45" />
+  <package id="Microsoft.Owin.SelfHost" version="4.2.2" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The bot seems to have updated the `Microsoft.Owin` package from 3.0.0 to 4.2.2, but forgot to update all the other `Microsoft.Owin.*` packages. This change fixes that and allows compiling the project again.