### PR TITLE
Update WhoAmI.aspx to support Negotiate to NTLM fallback

### DIFF
--- a/samples/aspnet/Identity/CurrentUserInfoRetrieval/WhoAmI.aspx
+++ b/samples/aspnet/Identity/CurrentUserInfoRetrieval/WhoAmI.aspx
@@ -26,7 +26,7 @@
             if (authHeader !=null && authHeader.StartsWith("Negotiate YII", StringComparison.OrdinalIgnoreCase))
                 //append Kerberos to the authentication method
                 lblAuthMethod.Text = lblAuthMethod.Text + " (KERBEROS)";
-            else if(authHeader != null && authHeader.StartsWith("NTLM", StringComparison.OrdinalIgnoreCase))
+            else if(authHeader != null && authHeader.StartsWith("Negotiate TlRM", StringComparison.OrdinalIgnoreCase))
                 //append NTLM to the authentication method
                 lblAuthMethod.Text = lblAuthMethod.Text + " (NTLM - fallback)" ;
             else


### PR DESCRIPTION
Detection of Negotiate to NTLM fallback was not being detected as expected because of an invalid if clause condition.